### PR TITLE
Fix get_uri() if board url contains ports, e.g. the board is running on ...

### DIFF
--- a/core/url.php
+++ b/core/url.php
@@ -287,21 +287,6 @@ class url
 	*/
 	public function get_uri($route)
 	{
-		$is_secure = $this->request->server('HTTPS', '');
-		$url = $this->config['server_name'];
-		if ($is_secure == 'on')
-		{
-			$url = 'https://' . $url;
-		}
-		else
-		{
-			$url = 'http://' . $url;
-		}
-
-		$split = parse_url($url);
-
-		$uri = $split['scheme'] . '://' . $split['host'] . $route;
-
-		return $uri;
+		return generate_board_url() . $route;
 	}
 }


### PR DESCRIPTION
...a non-standard HTTP port